### PR TITLE
added port number to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - 5900
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
+            - HUB_PORT_4444_TCP_PORT=4444
         depends_on:
             - hub
 
@@ -29,5 +30,6 @@ services:
             - 5900
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
+            - HUB_PORT_4444_TCP_PORT=4444
         depends_on:
             - hub


### PR DESCRIPTION
I added port number, so chrome and firefox selenium scripts would use correct URL so they can connect to hub.

This fixed bug #12 